### PR TITLE
Fix the post format of the Mastodon stream to append a correct mention list to a replying toot. (#7)

### DIFF
--- a/kovot/stream/mastodon.py
+++ b/kovot/stream/mastodon.py
@@ -3,13 +3,15 @@
 import collections.abc
 from html.parser import HTMLParser
 from mastodon import StreamListener, MastodonError, Mastodon as MastodonAPI
+from collections import OrderedDict
 from queue import Queue
 from kovot import Message, Response, Speaker
 from logging import Logger
-from typing import Iterator, List
+from typing import Iterator, List, Tuple
 __all__ = ['Mastodon']
 
-_TOOT_LIMIT = 500
+TOOT_LIMIT: int = 500
+CACHE_SIZE: int = 16
 
 
 class Mastodon(collections.abc.Iterable):
@@ -30,7 +32,8 @@ class Mastodon(collections.abc.Iterable):
             client_id: str,
             client_secret: str,
             access_token: str,
-            api_base_url: str
+            api_base_url: str,
+            reply_everyone: bool = False
     ):
         self.logger = logger
         self.api = MastodonAPI(
@@ -39,15 +42,26 @@ class Mastodon(collections.abc.Iterable):
             access_token,
             api_base_url
         )
+        self.myself = self.api.account_verify_credentials()
+        self.reply_everyone = reply_everyone
+        self._cached = dict()
 
     def __iter__(self) -> Iterator:
         listener = _TootListener()
         self.api.stream_user(listener, run_async=True)
+        self._cached = listener.cache
         return iter(listener)
 
     def post(self, response: Response) -> bool:
         self.logger.info("Trying to toot: " + response.text)
-        if len(response.text) > _TOOT_LIMIT:
+        if response.message is not None and response.message.id_ in self._cached:
+            in_reply_to = self._cached[response.message.id_]
+            if self.reply_everyone:
+                for user in reversed(in_reply_to['mentions']):
+                    if user['id'] != self.myself['id']:
+                        response.text = '@%s %s' % (user['acct'], response.text)
+            response.text = '@%s %s' % (in_reply_to['account']['acct'], response.text)
+        if len(response.text) > TOOT_LIMIT:
             self.logger.error('Length of given status has exceeded the limit: %d' % len(response.text))
             return False
         try:
@@ -62,6 +76,45 @@ class Mastodon(collections.abc.Iterable):
         return True
 
 
+class _CleansingParser(HTMLParser):
+    """
+    This class provides a function which removes HTML tags appearing in toots.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super(_CleansingParser, self).__init__(*args, **kwargs)
+        self.sb: List[str] = []
+        self._skip: bool = False
+
+    def __str__(self) -> str:
+        return ''.join(self.sb)
+
+    def _append(self, text: str) -> None:
+        if self._skip:
+            return
+        self.sb.append(text)
+
+    def handle_starttag(self, tag: str, attrs: List[Tuple[str, str]]) -> None:
+        self._strip = False
+        attr = {name: value for name, value in attrs}
+        classes = attr['class'].split() if 'class' in attr else []
+        if tag == 'br':
+            self._append('\n')
+        if tag == 'a' and 'mention' in classes:
+            self._skip = True
+
+    def handle_endtag(self, tag: str) -> None:
+        if self._skip and tag == 'a':
+            self._skip = False
+            self._strip = True
+
+    def handle_data(self, data: str) -> None:
+        if self._strip:
+            data = data.lstrip()
+        self._strip = False
+        self._append(data)
+
+
 class _TootListener(collections.abc.Iterable, StreamListener):
     """
     A listener collecting only toots related to the connected account, that is, mentions sent to the account.
@@ -71,14 +124,20 @@ class _TootListener(collections.abc.Iterable, StreamListener):
     ----------
     queue: queue.Queue
         A queue for processing collected toots in order.
+    cache: collections.OrderedDict
+        This attribute caches recent raw results given by Mastodon API.
     """
 
     def __init__(self):
         self.queue = Queue()
+        self.cache = OrderedDict()
 
     def __iter__(self) -> Iterator[Message]:
         while True:
             raw = self.queue.get()
+            self.cache[raw['id']] = raw
+            while len(self.cache) > CACHE_SIZE:
+                self.cache.popitem(last=False)
             content = self._cleanse_html(raw['content'])
             speaker = Speaker(raw['account']['display_name'])
             yield Message(content, id_=raw['id'], speaker=speaker)
@@ -89,17 +148,6 @@ class _TootListener(collections.abc.Iterable, StreamListener):
 
     @staticmethod
     def _cleanse_html(html: str) -> str:
-        class Parser(HTMLParser):
-            def __init__(self, *args, **kwargs):
-                super(Parser, self).__init__(*args, **kwargs)
-                self.sb: List[str] = []
-
-            def __str__(self) -> str:
-                return ''.join(self.sb)
-
-            def handle_data(self, data: str) -> None:
-                self.sb.append(data)
-
-        parser = Parser(convert_charrefs=True)
+        parser = _CleansingParser(convert_charrefs=True)
         parser.feed(html)
         return str(parser)


### PR DESCRIPTION
Dear kenkov-san,

Thank you for giving me your advice in issue #7.

Reversing the dependency between `Bot` and a stream object implicitly means that a `Respnse` object corresponds to a given `Message` object.
This implies that we can solve issue #7 by only remembering (additional) informations of recent received toots.
Hence, this pull requests add caching informations of recent received toots to _TootListener class.

This implementation can add a correct account list to a replying toot while it hide informations depended on Mastodon API from `Bot` and `Mod` objects.
I set the size of this cache (`CACHE_SIZE`) as 16 temporarily.

Best regards.